### PR TITLE
Add ClawdTalk - Phone calling and SMS for OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,9 @@ Build monetizable AI agents with these frameworks:
 
 - [**openclaw/clawhub**](https://github.com/openclaw/clawhub) ⭐ 1.4k - Official skill directory and marketplace.
 
+- [**ClawdTalk**](https://github.com/team-telnyx/clawdtalk-client) ⭐ - Phone calling and SMS for OpenClaw via Telnyx. AI agents can make/receive calls and SMS with calendar, Jira, and web search integration.
+  - 💰 **Monetize:** AI voice agent service, automated customer support lines, appointment reminder callbacks
+
 ---
 
 ## Workflow Automation


### PR DESCRIPTION
Add ClawdTalk to the OpenClaw Skills section.

ClawdTalk enables phone calling and SMS capabilities for OpenClaw agents, with monetization potential for AI voice agent services.