### PR TITLE
Add VARRD: Statistical edge discovery for trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ curl -fsSL https://blockrun.ai/ClawRouter-update | bash
 - [**TradingAgents**](https://github.com/TradingAgents-AI/TradingAgents) - Multi-agent trading framework with specialized analyst, researcher, and trader agents.
   - 💰 **Monetize:** Enterprise trading solutions, custom agent development
 
+- [**VARRD**](https://github.com/augiemazza/varrd) ⭐ 7 - Statistical edge discovery engine. Test any trading idea in plain English — runs event studies, backtests, and out-of-sample validation with 18 infrastructure-enforced guardrails against overfitting. Generates strategies for Freqtrade, Jesse, and more. CLI, Python SDK, or MCP server.
+  - 💰 **Monetize:** Validated strategy licensing, edge-as-a-service for funded traders, signal subscriptions, quant consulting
+
 ### Solana Trading
 
 - [**Solana Trading Bot**](https://github.com/warp-id/solana-trading-bot) ⭐ 2.3k - Beta Solana trading bot. Sniper, swap, and automated trading.


### PR DESCRIPTION
VARRD is a statistical edge discovery engine that turns plain-English trading ideas into validated trade setups. It enforces institutional-grade quant guardrails (K-tracking, Bonferroni correction, OOS lock) so you can't accidentally overfit.

- PyPI: https://pypi.org/project/varrd/
- MCP server: https://app.varrd.com/mcp
- Web app: https://app.varrd.com

Works as CLI (`varrd research "idea"`), Python SDK, or MCP server for AI agents.