### PR TITLE
Add keepmyclaw — backup-as-a-service skill for OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,9 @@ Tools for deploying, hosting, monitoring, and securing OpenClaw AI agents in pro
 - [**ClawdTalk**](https://github.com/team-telnyx/clawdtalk-client) - Phone calling and SMS for OpenClaw via Telnyx. AI agents can make/receive calls and SMS with calendar, Jira, and web search integration.
   - 💰 **Monetize:** AI voice agent service, automated customer support lines, appointment reminder callbacks
 
+- [**keepmyclaw**](https://keepmyclaw.com) - Encrypted cloud backup and restore for OpenClaw workspaces. Daily automated snapshots to Cloudflare R2, client-side AES-256-GCM encryption, one-command restore and migration. [ClawHub](https://clawhub.ai/benriazy/keepmyclaw)
+  - 💰 **Monetize:** SaaS backup subscriptions, disaster recovery plans, managed backup service for teams running OpenClaw fleets
+
 ---
 
 ## Workflow Automation


### PR DESCRIPTION
## keepmyclaw

[keepmyclaw](https://keepmyclaw.com) is a paid backup-as-a-service skill for OpenClaw workspaces.

### How it makes money
- **SaaS backup subscriptions** — monthly plans for automated encrypted cloud backups
- **Disaster recovery plans** — managed restore and migration services
- **Fleet backup management** — backup services for teams running multiple OpenClaw instances

### Features
- Daily automated snapshots to Cloudflare R2
- Client-side AES-256-GCM encryption (data encrypted before leaving the machine)
- One-command restore and migration to new devices
- Backup verification via restore drills

### Links
- Website: [keepmyclaw.com](https://keepmyclaw.com)
- ClawHub: [clawhub.ai/benriazy/keepmyclaw](https://clawhub.ai/benriazy/keepmyclaw)

Added to the **OpenClaw Skills** section as a monetizable backup skill.