### PR TITLE
feat: add The Stall — 210 pay-per-call data tools via MCP + x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,9 @@ Model Context Protocol (MCP) enables AI agents to connect to external tools and 
 - [**blockrun-mcp**](https://github.com/BlockRunAI/blockrun-mcp) ⭐ 465 - Live data for AI agents — search, research, markets, crypto, X/Twitter. Pay-per-call via x402 micropayments. Also available hosted at [`mcp.blockrun.ai`](https://github.com/BlockRunAI/blockrun-mcp-server) (zero install).
   - 💰 **Monetize:** Build paid data agents, package research workflows, charge per-report with USDC micropayments
 
+- [**The Stall**](https://github.com/thebrierfox/the-stall) - 209 pay-per-call data tools via MCP + x402 micropayments. US/EU/JP stocks, crypto/DeFi intelligence, options GEX, dealer gamma exposure, congressional trades, global news (GDELT), weather history, social momentum, sanctions screening. Hosted at [`the-stall.intuitek.ai/mcp`](https://the-stall.intuitek.ai/mcp). USDC on Base.
+  - 💰 **Monetize:** Plug pay-per-call market data into Franklin, trading bots, or MCP agent pipelines — pay only for what agents actually consume instead of $500+/mo API subscriptions
+
 - [**MindsDB**](https://github.com/mindsdb/mindsdb) ⭐ 38.5k - Federated Query Engine for AI. The only MCP Server you'll ever need for database access.
   - 💰 **Monetize:** Data pipeline services, enterprise AI data integration, managed MindsDB hosting
 


### PR DESCRIPTION
## Summary

Adds **The Stall** to the **Data & APIs** section under **MCP Servers & Tools**.

The Stall is an x402-native MCP server with 210 pay-per-call data capabilities — the same micropayment model that powers blockrun-mcp, but focused on data: stocks, crypto/DeFi, options GEX, dealer gamma exposure, congressional trades, global news (GDELT), weather history (85yr ERA5), social momentum, sanctions screening. USDC on Base. No API keys required.

### Why it fits here

- Pay-per-call via x402 micropayments (same model as blockrun-mcp)
- Directly usable from Franklin agent workflows for market data
- Fills the data layer that trading bots and research agents need
- Hosted at  — zero install

### Entry location

Added immediately after blockrun-mcp in the Data & APIs section.
