### PR TITLE
Add skill: js-creamlon (GAP async paid task handoff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,9 @@ Tools for deploying, hosting, monitoring, and securing OpenClaw AI agents in pro
 - [**ClawdTalk**](https://github.com/team-telnyx/clawdtalk-client) - Phone calling and SMS for OpenClaw via Telnyx. AI agents can make/receive calls and SMS with calendar, Jira, and web search integration.
   - 💰 **Monetize:** AI voice agent service, automated customer support lines, appointment reminder callbacks
 
+- [**js-creamlon**](https://github.com/imjszhang/js-creamlon) - Turn any GitHub repo into a **melon** — an async agent service store. Sellers publish a service catalog, buyers place orders as Issues, every delivery gets an Ed25519 signed receipt. Supports x402, Stripe, or any payment rail. Complements sync micropayment rails like ClawRouter.
+  - 💰 **Monetize:** Open a melon to sell async agent services (code review, report generation, data cleanup) with verifiable delivery and one-time access passes
+
 ---
 
 ## Workflow Automation


### PR DESCRIPTION
Adds js-creamlon to the OpenClaw Skills section.

## What it is

GitHub Agent Protocol (GAP) — async paid task handoff via GitHub Issues with verifiable delivery:

1. Pay via x402 micropayment (complements ClawRouter sync calls)
2. Mint a one-time credential scoped to the task
3. Worker completes the task and posts Ed25519 signed delivery proof
4. Caller verifies the signature before accepting

## How to monetize

- Run a paid agent node that earns per completed task (code review, report generation, refactoring)
- Sell async agent services with cryptographic delivery proof — buyers can verify independently

## Links

- Repo: https://github.com/imjszhang/js-creamlon
- ClawHub skill: https://clawhub.ai/skills/creamlon-skill
- Protocol reference: https://github.com/imjszhang/js-creamlon/blob/main/references/protocol.md

Made with [Cursor](https://cursor.com)