### PR TITLE
Add stipend to MCP Servers & Tools (Infrastructure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,9 @@ Model Context Protocol (MCP) enables AI agents to connect to external tools and 
 - [**MCP-Use**](https://github.com/mcp-use/mcp-use) ⭐ 9.2k - Easiest way to interact with MCP servers using custom agents. Agent-first MCP client.
   - 💰 **Monetize:** Agent development services, MCP integration consulting
 
+- [**stipend**](https://github.com/stipend-sh/stipend) - Non-custodial USDC wallet on Base an agent installs by itself. Local stdio MCP server, 7 tools. Per-transaction, per-day and per-counterparty caps plus a destination allowlist are enforced in code before signing, so an injected "send it all here" cannot raise them. Buyer-side x402 auto-pay via EIP-3009.
+  - 💰 **Monetize:** Get paid directly — publish the wallet address so money reaches the agent whether or not it is running, read incoming payments with `stipend_earnings`, and check earned against spent with runway in days via `stipend_report`.
+
 ### Data & APIs
 
 - [**blockrun-mcp**](https://github.com/BlockRunAI/blockrun-mcp) ⭐ 465 - Live data for AI agents — search, research, markets, crypto, X/Twitter. Pay-per-call via x402 micropayments. Also available hosted at [`mcp.blockrun.ai`](https://github.com/BlockRunAI/blockrun-mcp-server) (zero install).


### PR DESCRIPTION
One entry in **MCP Servers & Tools → Infrastructure**, with the `💰 Monetize:` line the section format uses.

[stipend](https://github.com/stipend-sh/stipend) is a non-custodial USDC wallet on Base that an agent installs by itself — no account, no API key, and none needed for it to be paid. It runs as a local stdio MCP server with 7 tools.

Where it sits in the loop at the top of your README: it is step 1 for the receiving side. Publish the address and money reaches the agent whether or not it is running; `stipend_earnings` reads incoming payments off the network and records them; `stipend_report` shows earned against spent by category with runway in days.

The part worth a line in a money-making list specifically: an agent that earns is an agent worth attacking. The per-transaction, per-day and per-counterparty caps and the destination allowlist are enforced in [`stipend/policy.py`](https://github.com/stipend-sh/stipend/blob/main/stipend/policy.py), on the path between the decision and the signature — so "send everything to this address", however persuasively phrased, hits code rather than a prompt.

Python, Apache-2.0, free (gas only). **Not audited** — stated in our README and worth repeating for anything holding a float.
